### PR TITLE
fix rotational equivariance test

### DIFF
--- a/clebsch_gordan.py
+++ b/clebsch_gordan.py
@@ -2,14 +2,17 @@ from functools import lru_cache
 import e3nn_jax
 # from e3x.so3 import clebsch_gordan
 from e3nn.o3._wigner import _so3_clebsch_gordan
+from e3x.so3._symbolic import _clebsch_gordan
 
 
 def get_clebsch_gordan(l1: int, l2: int, l3: int, m1: int, m2: int, m3: int) -> float:
-    cg = _get_clebsch_gordan(l1, l2, l3)
+    # cg = _get_clebsch_gordan(l1, l2, l3)
+    res = float(_clebsch_gordan(l1, l2, l3, m1,m2,m3).evalf())
+    return res
     # print("e3nn cg shape", cg.shape)
 
     # I'm pretty sure we add each li to mi because mi starts at -li. So we need to offset it by li
-    return cg[l1 + m1, l2 + m2, l3 + m3]
+    # return cg[l1 + m1, l2 + m2, l3 + m3]
 
 @lru_cache(maxsize=None)
 def _get_clebsch_gordan(l1: int, l2: int, l_out: int) -> str:

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 
-default_dtype = jnp.float64
+default_dtype = jnp.float32
 EVEN_PARITY = 1 # a mnemonic to remember this is: "multiplying by 1 doesn't change the sign"
 ODD_PARITY = -1
 

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 
-default_dtype = jnp.float32
+default_dtype = jnp.float64
 EVEN_PARITY = 1 # a mnemonic to remember this is: "multiplying by 1 doesn't change the sign"
 ODD_PARITY = -1
 

--- a/spherical_harmonics.py
+++ b/spherical_harmonics.py
@@ -29,7 +29,7 @@ import jax
 def map_3d_feats_to_spherical_harmonics_repr(feats_3d: Float[Array, "num_feats 3"], normalize: bool=False) -> Irrep:
     # print(feats_3d.block_until_ready())
     num_feats = feats_3d.shape[0]
-    max_l = 4
+    max_l = 1
     num_coefficients_per_feat = (max_l+1)**2 # l=0 has 1 coefficient, l=1 has 3. so 4 total coefficients
     arr = jnp.zeros((2, num_coefficients_per_feat, num_feats), dtype=default_dtype)
 

--- a/spherical_harmonics.py
+++ b/spherical_harmonics.py
@@ -29,7 +29,7 @@ import jax
 def map_3d_feats_to_spherical_harmonics_repr(feats_3d: Float[Array, "num_feats 3"], normalize: bool=False) -> Irrep:
     # print(feats_3d.block_until_ready())
     num_feats = feats_3d.shape[0]
-    max_l = 1 # l=1 since we're dealing with 3D features
+    max_l = 4
     num_coefficients_per_feat = (max_l+1)**2 # l=0 has 1 coefficient, l=1 has 3. so 4 total coefficients
     arr = jnp.zeros((2, num_coefficients_per_feat, num_feats), dtype=default_dtype)
 

--- a/tensor_product.py
+++ b/tensor_product.py
@@ -53,7 +53,7 @@ def tensor_product_v1(irrep1: Irrep, irrep2: Irrep, max_l3: Optional[int] = None
                                         cg = get_clebsch_gordan(l1, l2, l3, m1, m2, m3)
                                         if cg == 0:
                                             continue
-                                        # normalization =  math.sqrt(2 * l3 + 1)
+                                        # normalization = math.sqrt(2 * l3 + 1)
                                         # normalization = math.sqrt(num_coefficients_per_feat)
                                         normalization = 1
                                         # print("CG coefficient:", cg, l3, m3)

--- a/tensor_product.py
+++ b/tensor_product.py
@@ -62,59 +62,6 @@ def tensor_product_v1(irrep1: Irrep, irrep2: Irrep, max_l3: Optional[int] = None
     return out
 
 
-# same thing as above, but the output features is 
-def tensor_product_v1dot1(irrep1: Irrep, irrep2: Irrep) -> jnp.ndarray:
-    max_l1 = irrep1.l()
-    max_l2 = irrep2.l()
-    num_irrep1_feats = irrep1.multiplicity()
-    num_irrep2_feats = irrep2.multiplicity()
-    num_output_feats = num_irrep1_feats * num_irrep2_feats
-
-    max_output_l = max_l1 + max_l2
-    num_coefficients_per_feat = (max_output_l + 1) ** 2
-    out = jnp.zeros((NUM_PARITY_DIMS, num_coefficients_per_feat, num_output_feats), dtype=jnp.float32)
-
-    for feat1_idx in range(num_irrep1_feats):
-        for feat2_idx in range(num_irrep2_feats):
-            for parity1_idx in PARITY_IDXS:
-                for parity2_idx in PARITY_IDXS:
-                    if irrep1.is_feature_zero(parity1_idx, feat1_idx) or irrep2.is_feature_zero(parity2_idx, feat2_idx):
-                        continue
-                    feat3_idx = feat1_idx * num_irrep2_feats + feat2_idx
-                    parity3 = parity_idx_to_parity(parity1_idx) * parity_idx_to_parity(parity2_idx)
-                    parity3_idx = parity_to_parity_idx(parity3)
-
-                    for l1 in range(max_l1 + 1):
-                        for m1 in range(-l1, l1 + 1):
-                            v1 = irrep1.get_coefficient(parity1_idx, feat1_idx, l1, m1)
-                            if v1 == 0:
-                                continue
-                            for l2 in range(max_l2 + 1):
-                                for m2 in range(-l2, l2 + 1):
-                                    v2 = irrep2.get_coefficient(parity2_idx, feat2_idx, l2, m2)
-                                    if v2 == 0:
-                                        continue
-                                    l3_min = abs(l1 - l2)
-                                    l3_max_current = l1 + l2
-                                    for l3 in range(l3_min, l3_max_current + 1):
-                                        if l3 > max_output_l:
-                                            continue
-                                        m3 = m1 + m2
-                                        if m3 < -l3 or m3 > l3:
-                                            continue
-                                        cg = get_clebsch_gordan(l1, l2, l3, m1, m2, m3)
-                                        if cg == 0:
-                                            continue
-                                        # normalization =  math.sqrt(2 * l3 + 1)
-                                        # normalization = math.sqrt(num_coefficients_per_feat)
-                                        normalization = 1
-                                        # print("CG coefficient:", cg, l3, m3)
-                                        coef_idx = Irrep.coef_idx(l3, m3)
-                                        out = out.at[parity3_idx, coef_idx, feat3_idx].add(cg * v1 * v2 * normalization)
-    return out
-
-
-
 # how do you do the tensor product if you have n irreps for one input, and m irreps for the other input?
 # we do n*m tensor products
 

--- a/train.py
+++ b/train.py
@@ -149,8 +149,8 @@ class Model(flax.linen.Module):
         # layers = 2 * ["32x0e + 32x0o + 8x1o + 8x1e + 8x2e + 8x2o"] + ["0o + 7x0e"]
 
         # for irreps in layers:
-        graphs = e3jLayer(max_l=2, denominator=1)(graphs, positions)
-        graphs = e3jLayer(max_l=3, denominator=1)(graphs, positions)
+        graphs = e3jLayer(max_l=5, denominator=1)(graphs, positions)
+        graphs = e3jLayer(max_l=9, denominator=1)(graphs, positions)
         graphs = e3jFinalLayer()(graphs)
         logits = graphs.globals
 
@@ -260,6 +260,7 @@ def test_equivariance(model: Model, params: jnp.ndarray):
 
     print("logits", logits)
     print("rotated logits", rotated_logits)
+    print("logit diff distance", jnp.sum(jnp.abs(logits - rotated_logits)))
     assert jnp.allclose(logits, rotated_logits, atol=1e-2), "model is not equivariant"
 
 


### PR DESCRIPTION
### Using this rotation matrix:
```
rotation_matrix = jnp.array([
     [0.7071, 0.5, 0.5],
     [0, 0.7071, -0.7071],
     [-0.7071, 0.5, 0.5],
])
```

the error decreases when I use more spherical harmonics coefficients (when encoding the 3d vector):

l=1:
logits [[-1.16042974 -0.14532735  0.36908284 -1.06829192  0.05887733  0.54958118
  -0.49035633]]
rotated logits [[-1.1709692  -0.14178999  0.36371258 -1.07215245  0.04320098  0.54674098
  -0.49984807]]
logit diff distance 0.05131587965283643


l=2 logits:
logits [[ 0.14968545  0.27725489  0.05433957 -0.54589031  0.07869813  0.04497507
   0.27035578]]
rotated logits [[ 0.14338414  0.27723502  0.0407705  -0.54264266  0.08011795  0.05180874
   0.27023944]]
logit diff distance 0.03150772741114719



l=4:
update edge fn finished
logits [[-0.07339231  0.07445705  0.13254733 -0.1758875   0.07739835 -0.04782718
   0.20062505]]
rotated logits [[-0.0718594   0.07055889  0.130827   -0.17248872  0.07431458 -0.04982356
   0.20865867]]
logit diff distance 0.023663948613603436

# Problem solved

The problem with the rotation matrix is that it didn't have enough degrees of freedom. using a new function (with more precision) drastically decreases the rotational error