### PR TITLE
Enable jit

### DIFF
--- a/irrep.py
+++ b/irrep.py
@@ -61,7 +61,7 @@ class Irrep():
     def slice_ith_feature(self, ith_feature: int) -> float:
         return jnp.expand_dims(self.array[:, :, ith_feature], axis=-1)
     # returns true if there is no feature at the given parity and index i
-    def is_feature_zero(self, parity_idx: int, ith_feature: int) -> bool:
+    def is_feature_zero(self, parity_idx: int, ith_feature: int) -> jnp.bool_:
         subset = self.get_ith_feature(parity_idx, ith_feature)
         # print("subset:", subset, jnp.all(subset == 0))
         return jnp.all(subset == 0)

--- a/spherical_harmonics.py
+++ b/spherical_harmonics.py
@@ -10,6 +10,8 @@ from constants import ODD_PARITY_IDX, EVEN_PARITY, default_dtype
 import numpy as np
 from jaxtyping import Array, Float
 import jax
+from e3x.so3._spherical_harmonics_lut import _generate_spherical_harmonics_lookup_table
+from e3x.so3.irreps import spherical_harmonics, solid_harmonics
 # from jax import jit
 
 # @jit
@@ -26,6 +28,13 @@ import jax
 # Important! spherical harmonics are the angular solutions to the Laplace equation. So we normalize
 # the feature before mapping to a representation via spherical harmonics
 # This means that two vectors of different lengths but facing the same direction will have the same representation
+
+# _generate_spherical_harmonics_lookup_table(
+#       max_degree=2, num_processes=4
+# )
+
+
+# If you look at the spherical harmonics here: http://openmopac.net/manual/real_spherical_harmonics.html, you'll see that each cartesian axis is raised to the same power
 def map_3d_feats_to_spherical_harmonics_repr(feats_3d: Float[Array, "num_feats 3"], normalize: bool=False) -> Irrep:
     num_feats = feats_3d.shape[0]
     max_l = 2
@@ -44,8 +53,9 @@ def map_3d_feats_to_spherical_harmonics_repr(feats_3d: Float[Array, "num_feats 3
                 magnitude = jnp.linalg.norm(feat)
                 feat = (feat / magnitude)
 
-                coefficient = float(_spherical_harmonics(l, m)(*feat.tolist()))
+                # coefficient = float(_spherical_harmonics(l, m)(*feat.tolist()))
                 # coefficient = float(e3x.so3._symbolic._spherical_harmonics(l, m)(*feat))
+                coefficient = solid_harmonics(feat, l, cartesian_order=False)[m + l]
 
                 # https://chatgpt.com/share/67306530-4680-800e-b259-fd767593126c
                 # be careful to assign the right parity to the coefficients!

--- a/tensor_product.py
+++ b/tensor_product.py
@@ -3,10 +3,10 @@ from clebsch_gordan import get_clebsch_gordan
 from constants import NUM_PARITY_DIMS, PARITY_IDXS
 from parity import parity_idx_to_parity, parity_to_parity_idx
 from irrep import Irrep
+import jax
 import jax.numpy as jnp
-import math
 
-
+@jax.jit
 def tensor_product_v1(irrep1: Irrep, irrep2: Irrep, max_l3: Optional[int] = None) -> jnp.ndarray:
     max_l1 = irrep1.l()
     max_l2 = irrep2.l()
@@ -20,49 +20,110 @@ def tensor_product_v1(irrep1: Irrep, irrep2: Irrep, max_l3: Optional[int] = None
         max_output_l = max_l3
 
     num_coefficients_per_feat = (max_output_l + 1) ** 2
-    out = jnp.zeros((NUM_PARITY_DIMS, num_coefficients_per_feat, num_output_feats), dtype=jnp.float32)
+    out_shape = (NUM_PARITY_DIMS, num_coefficients_per_feat, num_output_feats)
 
-    for feat1_idx in range(num_irrep1_feats):
-        for feat2_idx in range(num_irrep2_feats):
-            for parity1_idx in PARITY_IDXS:
-                for parity2_idx in PARITY_IDXS:
-                    if jnp.logical_or( irrep1.is_feature_zero(parity1_idx, feat1_idx), irrep2.is_feature_zero(parity2_idx, feat2_idx)):
-                        continue
-                    feat3_idx = feat1_idx * num_irrep2_feats + feat2_idx
-                    parity3 = parity_idx_to_parity(parity1_idx) * parity_idx_to_parity(parity2_idx)
-                    parity3_idx = parity_to_parity_idx(parity3)
+    # Generate indices for vectorization
+    feat1_indices = jnp.arange(num_irrep1_feats)
+    feat2_indices = jnp.arange(num_irrep2_feats)
+    parity_indices = jnp.array(PARITY_IDXS)
 
-                    for l1 in range(max_l1 + 1):
-                        for m1 in range(-l1, l1 + 1):
-                            v1 = irrep1.get_coefficient(parity1_idx, feat1_idx, l1, m1)
-                            if v1 == 0:
-                                continue
-                            for l2 in range(max_l2 + 1):
-                                for m2 in range(-l2, l2 + 1):
-                                    v2 = irrep2.get_coefficient(parity2_idx, feat2_idx, l2, m2)
-                                    if v2 == 0:
-                                        continue
-                                    l3_min = abs(l1 - l2)
-                                    l3_max_current = l1 + l2
-                                    for l3 in range(l3_min, l3_max_current + 1):
-                                        if l3 > max_output_l:
-                                            continue
-                                        m3 = m1 + m2
-                                        if m3 < -l3 or m3 > l3:
-                                            continue
-                                        cg = get_clebsch_gordan(l1, l2, l3, m1, m2, m3)
-                                        if cg == 0:
-                                            continue
-                                        # normalization = math.sqrt(2 * l3 + 1)
-                                        # normalization = math.sqrt(num_coefficients_per_feat)
-                                        normalization = 1
-                                        # print("CG coefficient:", cg, l3, m3)
-                                        coef_idx = Irrep.coef_idx(l3, m3)
-                                        out = out.at[parity3_idx, coef_idx, feat3_idx].add(cg * v1 * v2 * normalization)
-    return out
+    # Generate all combinations of indices
+    indices = jnp.array(
+        jnp.meshgrid(feat1_indices, feat2_indices, parity_indices, parity_indices, indexing='ij')
+    ).reshape(4, -1).T
 
+    # Vectorize over features and parities
+    def compute_output(feat_indices):
+        feat1_idx, feat2_idx, parity1_idx, parity2_idx = feat_indices
 
-# how do you do the tensor product if you have n irreps for one input, and m irreps for the other input?
-# we do n*m tensor products
+        # Check if features are zero
+        is_zero1 = irrep1.is_feature_zero(parity1_idx, feat1_idx)
+        is_zero2 = irrep2.is_feature_zero(parity2_idx, feat2_idx)
+        if is_zero1 or is_zero2:
+            # Return zero updates
+            return jnp.zeros(out_shape, dtype=jnp.float32)
 
-# where does e3nn and e3x apply the weights?
+        feat3_idx = feat1_idx * num_irrep2_feats + feat2_idx
+        parity1 = parity_idx_to_parity(parity1_idx)
+        parity2 = parity_idx_to_parity(parity2_idx)
+        parity3 = parity1 * parity2
+        parity3_idx = parity_to_parity_idx(parity3)
+
+        # Generate l and m values
+        l1_values = jnp.arange(max_l1 + 1)
+        l2_values = jnp.arange(max_l2 + 1)
+
+        # Initialize updates for this computation
+        updates = jnp.zeros(out_shape, dtype=jnp.float32)
+
+        # Vectorized computation over l1, m1, l2, m2
+        def compute_inner_loops(l1):
+            m1_values = jnp.arange(-l1, l1 + 1)
+            def compute_m1(m1):
+                v1 = irrep1.get_coefficient(parity1_idx, feat1_idx, l1, m1)
+                if v1 == 0:
+                    return jnp.zeros(out_shape, dtype=jnp.float32)
+
+                def compute_l2(l2):
+                    m2_values = jnp.arange(-l2, l2 + 1)
+                    def compute_m2(m2):
+                        v2 = irrep2.get_coefficient(parity2_idx, feat2_idx, l2, m2)
+                        if v2 == 0:
+                            return jnp.zeros(out_shape, dtype=jnp.float32)
+
+                        l3_min = abs(l1 - l2)
+                        l3_max_current = min(l1 + l2, max_output_l)
+                        l3_values = jnp.arange(l3_min, l3_max_current + 1)
+                        m3 = m1 + m2
+
+                        # Filter valid l3 and m3 values
+                        valid_indices = (jnp.abs(m3) <= l3_values)
+                        l3_values = l3_values[valid_indices]
+                        m3_values = m3 * jnp.ones_like(l3_values)
+
+                        if l3_values.size == 0:
+                            return jnp.zeros(out_shape, dtype=jnp.float32)
+
+                        # Compute Clebsch-Gordan coefficients
+                        cg_values = get_clebsch_gordan(
+                            l1, l2, l3_values, m1, m2, m3_values
+                        )
+                        cg_values = cg_values * v1 * v2  # Multiply by coefficients
+                        normalization = 1  # Adjust normalization if needed
+
+                        coef_indices = Irrep.coef_idx(l3_values, m3_values)
+
+                        # Prepare indices for updating the output array
+                        parity_indices = parity3_idx * jnp.ones_like(coef_indices)
+                        feat_indices = feat3_idx * jnp.ones_like(coef_indices)
+
+                        # Create an update array
+                        update = jnp.zeros(out_shape, dtype=jnp.float32)
+                        update = update.at[
+                            parity_indices, coef_indices, feat_indices
+                        ].set(cg_values * normalization)
+                        return update
+
+                    # Compute over m2_values
+                    updates_m2 = jax.vmap(compute_m2)(m2_values)
+                    return updates_m2.sum(axis=0)
+
+                # Compute over l2_values
+                updates_l2 = jax.vmap(compute_l2)(l2_values)
+                return updates_l2.sum(axis=0)
+
+            # Compute over m1_values
+            updates_m1 = jax.vmap(compute_m1)(m1_values)
+            return updates_m1.sum(axis=0)
+
+        # Compute over l1_values
+        updates_l1 = jax.vmap(compute_inner_loops)(l1_values)
+        updates = updates_l1.sum(axis=0)
+
+        return updates
+
+    # Vectorize over all combinations
+    outputs = jax.vmap(compute_output)(indices)
+    # Sum over all outputs to get the final result
+    final_out = outputs.sum(axis=0)
+    return final_out

--- a/tensor_product.py
+++ b/tensor_product.py
@@ -26,7 +26,7 @@ def tensor_product_v1(irrep1: Irrep, irrep2: Irrep, max_l3: Optional[int] = None
         for feat2_idx in range(num_irrep2_feats):
             for parity1_idx in PARITY_IDXS:
                 for parity2_idx in PARITY_IDXS:
-                    if irrep1.is_feature_zero(parity1_idx, feat1_idx) or irrep2.is_feature_zero(parity2_idx, feat2_idx):
+                    if jnp.logical_or( irrep1.is_feature_zero(parity1_idx, feat1_idx), irrep2.is_feature_zero(parity2_idx, feat2_idx)):
                         continue
                     feat3_idx = feat1_idx * num_irrep2_feats + feat2_idx
                     parity3 = parity_idx_to_parity(parity1_idx) * parity_idx_to_parity(parity2_idx)

--- a/train.py
+++ b/train.py
@@ -287,5 +287,5 @@ def test_equivariance(model: Model, params: jnp.ndarray):
 
 if __name__ == "__main__":
     # TODO:(curtis): enable this after
-    with jax.disable_jit():
-        train()
+    # with jax.disable_jit():
+    train()


### PR DESCRIPTION
- I'm using default implementations in e3x for spherical harmonics because I would need to use a lookup table scheme like e3x does it if I want it to be jitted